### PR TITLE
Add support for extra AWS options in the querystring of URLs.

### DIFF
--- a/lib/s3-url.js
+++ b/lib/s3-url.js
@@ -2,7 +2,8 @@
 'use strict';
 
 var _ = require('lodash'),
-	url = require('url');
+	url = require('url'),
+	querystring = require('querystring');
 
 function optionsToUrl(options) {
 	if (!_.isObject(options)) {
@@ -13,7 +14,8 @@ function optionsToUrl(options) {
 		protocol: 's3:',
 		hostname: options.Bucket,
 		pathname: options.Key,
-		slashes: true
+		slashes: true,
+		query: _.omit(options, ['Bucket', 'Key'])
 	};
 
 	return url.format(parts);
@@ -22,11 +24,15 @@ function optionsToUrl(options) {
 function urlToOptions(parts) {
 
 	if (_.isString(parts)) {
-		parts = url.parse(parts);
+		parts = url.parse(parts, true);
 	}
 
 	if (!_.isObject(parts)) {
 		throw new TypeError();
+	}
+
+	if (_.isString(parts.query)) {
+		parts.query = querystring.parse(parts.query);
 	}
 
 	var options = {
@@ -36,8 +42,10 @@ function urlToOptions(parts) {
 	options.Bucket = parts.hostname;
 
 	if (parts.path) {
-		options.Key = parts.path;
+		options.Key = parts.pathname;
 	}
+
+	_.assign(options, parts.query);
 
 	return options;
 }

--- a/test/spec/s3-url.spec.js
+++ b/test/spec/s3-url.spec.js
@@ -23,6 +23,15 @@ describe('optionsToURL', function() {
 		});
 		expect(result).to.equal('s3://bucket');
 	});
+
+	it('should produce extended parameters', function() {
+		var result = s3Url.optionsToUrl({
+			Bucket: 'bucket',
+			Key: 'key',
+			ContentType: 'foo/bar'
+		});
+		expect(result).to.equal('s3://bucket/key?ContentType=foo%2Fbar');
+	});
 });
 
 describe('urlToOptions', function() {
@@ -52,5 +61,23 @@ describe('urlToOptions', function() {
 
 	it('should fail with nothing', function() {
 		expect(s3Url.urlToOptions).to.throw(TypeError);
+	});
+
+	it('should parse the query parameters', function() {
+		expect(s3Url.urlToOptions(url.parse('s3://bucket/key?ContentType=l')))
+			.to.deep.equal({
+				Bucket: 'bucket',
+				Key: '/key',
+				ContentType: 'l'
+			});
+	});
+
+	it('should parse the query parameters', function() {
+		expect(s3Url.urlToOptions('s3://bucket/key?ContentType=l'))
+			.to.deep.equal({
+				Bucket: 'bucket',
+				Key: '/key',
+				ContentType: 'l'
+			});
 	});
 });


### PR DESCRIPTION
Since maybe there are cases where additional options need to be passed to AWS, allow for providing them in the URL itself.
