### PR TITLE
Strip the leading "/" when parsing URLs.

### DIFF
--- a/lib/s3-url.js
+++ b/lib/s3-url.js
@@ -42,7 +42,8 @@ function urlToOptions(parts) {
 	options.Bucket = parts.hostname;
 
 	if (parts.path) {
-		options.Key = parts.pathname;
+		// Strip the leading "/"
+		options.Key = parts.pathname.substring(1);
 	}
 
 	_.assign(options, parts.query);

--- a/test/spec/s3-url.spec.js
+++ b/test/spec/s3-url.spec.js
@@ -40,7 +40,7 @@ describe('urlToOptions', function() {
 		expect(s3Url.urlToOptions(url.parse('s3://bucket/key')))
 			.to.deep.equal({
 				Bucket: 'bucket',
-				Key: '/key'
+				Key: 'key'
 			});
 	});
 
@@ -48,7 +48,7 @@ describe('urlToOptions', function() {
 		expect(s3Url.urlToOptions('s3://bucket/key'))
 			.to.deep.equal({
 				Bucket: 'bucket',
-				Key: '/key'
+				Key: 'key'
 			});
 	});
 
@@ -67,7 +67,7 @@ describe('urlToOptions', function() {
 		expect(s3Url.urlToOptions(url.parse('s3://bucket/key?ContentType=l')))
 			.to.deep.equal({
 				Bucket: 'bucket',
-				Key: '/key',
+				Key: 'key',
 				ContentType: 'l'
 			});
 	});
@@ -76,7 +76,7 @@ describe('urlToOptions', function() {
 		expect(s3Url.urlToOptions('s3://bucket/key?ContentType=l'))
 			.to.deep.equal({
 				Bucket: 'bucket',
-				Key: '/key',
+				Key: 'key',
 				ContentType: 'l'
 			});
 	});


### PR DESCRIPTION
This is so it matches how the key URLs are generated and is in line with S3; no keys in S3 start with a "/" prefix generally.
