### PR TITLE
Allow simple paths in addition to urls.

### DIFF
--- a/lib/s3-url.js
+++ b/lib/s3-url.js
@@ -24,6 +24,17 @@ function optionsToUrl(options) {
 function urlToOptions(parts) {
 
 	if (_.isString(parts)) {
+
+		// Someone just passed some arbitrary string that isn't an s3 URL, so
+		// assume they want that to be their key. This is kind of lenient but
+		// handy. Consider enforcing a strict mode in the future that does not
+		// support this.
+		if (!/^s3:/.exec(parts)) {
+			return {
+				Key: parts
+			};
+		}
+
 		parts = url.parse(parts, true);
 	}
 

--- a/test/spec/s3-url.spec.js
+++ b/test/spec/s3-url.spec.js
@@ -80,4 +80,11 @@ describe('urlToOptions', function() {
 				ContentType: 'l'
 			});
 	});
+
+	it('should accept paths instead of URLs', function() {
+		expect(s3Url.urlToOptions('some/key'))
+			.to.deep.equal({
+				Key: 'some/key'
+			});
+	});
 });


### PR DESCRIPTION
This enables some degree of backwards compatibility with people who are not yet using URLs.